### PR TITLE
Add iteration to import actions

### DIFF
--- a/trapp/command_line.py
+++ b/trapp/command_line.py
@@ -50,7 +50,7 @@ def main():
     elif (args.verb == 'import-games'):
         print('Importing games from ' + str(args.infile))
         log = Log('trapp-import-games.log')
-        # Need to receive filename from command line
+        # sample trapp/imports/games.xlsx
         importer = Importer(args.infile, log)
         # Check for required fields
         requiredColumns = ([
@@ -66,7 +66,8 @@ def main():
     elif (args.verb == 'import-players'):
         print('Importing players from ' + str(args.infile))
         log = Log('trapp-import-players.log')
-        importer = Importer('trapp/imports/players.xlsx', log)
+        # sample trapp/imports/players.xlsx
+        importer = Importer(args.infile, log)
         requiredColumns = ([
             'FirstName',
             'LastName',

--- a/trapp/importer.py
+++ b/trapp/importer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from trapp.spreadsheet import Spreadsheet
+from trapp.game import Game
 
 
 class Importer():
@@ -44,6 +45,14 @@ class Importer():
         # need to prepare records
         self.records = self.source.buildRecords()
         # need to iterate over records
+        [self.importRecord(record) for record in self.records]
+        return True
+
+    def importRecord(self, record):
+        print('Importing record...')
+        print(str(record))
+        g = Game()
+        g.saveDict(record, self.log)
         return True
 
     def setLog(self, log):

--- a/trapp/importer.py
+++ b/trapp/importer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from trapp.spreadsheet import Spreadsheet
-from trapp.game import Game
+# from trapp.game import Game
 
 
 class Importer():
@@ -51,8 +51,8 @@ class Importer():
     def importRecord(self, record):
         print('Importing record...')
         print(str(record))
-        g = Game()
-        g.saveDict(record, self.log)
+        # g = Game()
+        # g.saveDict(record, self.log)
         return True
 
     def setLog(self, log):

--- a/trapp/importer.py
+++ b/trapp/importer.py
@@ -41,7 +41,9 @@ class Importer():
         return True
 
     def doImport(self):
-
+        # need to prepare records
+        self.records = self.source.buildRecords()
+        # need to iterate over records
         return True
 
     def setLog(self, log):

--- a/trapp/spreadsheet.py
+++ b/trapp/spreadsheet.py
@@ -8,6 +8,19 @@ class Spreadsheet():
     def __init__(self, file):
         self.data = open_workbook(file)
 
+    def buildRecords(self):
+        self.records = []
+        self.sheet = self.buildSheet()
+        for row in xrange(1, self.sheet.nrows):
+            d = {self.fields[col]: self.sheet.cell(row, col).value for col in xrange(self.sheet.ncols)}
+            print(str(d))
+            self.records.append(d)
+        return self.records
+
+    def buildSheet(self):
+        self.sheet = self.data.sheets()[0]
+        return self.sheet
+
     def recoverDate(self, number):
         # This implements xlrd's 'xldate_as_tuple' method, which is then
         # rebuilt as a 9-item tuple rather than 6. Because reasons.

--- a/trapp/spreadsheet.py
+++ b/trapp/spreadsheet.py
@@ -13,7 +13,7 @@ class Spreadsheet():
         self.sheet = self.buildSheet()
         for row in xrange(1, self.sheet.nrows):
             d = {self.fields[col]: self.sheet.cell(row, col).value for col in xrange(self.sheet.ncols)}
-            d['MatchTime'] = self.recoverDate(d['MatchTime'])
+            # d['MatchTime'] = self.recoverDate(d['MatchTime'])
             self.records.append(d)
         return self.records
 

--- a/trapp/spreadsheet.py
+++ b/trapp/spreadsheet.py
@@ -13,7 +13,7 @@ class Spreadsheet():
         self.sheet = self.buildSheet()
         for row in xrange(1, self.sheet.nrows):
             d = {self.fields[col]: self.sheet.cell(row, col).value for col in xrange(self.sheet.ncols)}
-            print(str(d))
+            d['MatchTime'] = self.recoverDate(d['MatchTime'])
             self.records.append(d)
         return self.records
 


### PR DESCRIPTION
This adds a conversion step in the spreadsheet object to take a spreadsheet and return a list of dictionary objects. That should allow a cleaner actual import step?