### PR TITLE
Checks environment for db credentials before file; this closes #38

### DIFF
--- a/trapp/database.py
+++ b/trapp/database.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from mysql import connector
 import trapp.connection as connection
 import time
+import os
 
 
 class Database():
@@ -12,7 +13,17 @@ class Database():
         self.cursor = ''
 
     def connect(self):
-        self.cnx = connector.connect(user=connection.u, password=connection.p, host=connection.h, database=connection.d)
+        try:
+            dbuser = os.environ['trapp.dbuser']
+            dbpwd = os.environ['trapp.dbpwd']
+            dbhost = os.environ['trapp.dbhost']
+            dbschema = os.environ['trapp.dbschema']
+        except KeyError:
+            dbuser = connection.u
+            dbpwd = connection.p
+            dbhost = connection.h
+            dbschema = connection.d
+        self.cnx = connector.connect(user=dbuser, password=dbpwd, host=dbhost, database=dbschema)
         self.cursor = self.cnx.cursor(buffered=True)
 
     def disconnect(self):


### PR DESCRIPTION
This should prevent inadvertently committing real database credentials. The database object first checks the local environment for credential information in the following variables:

```
trapp.dbuser
trapp.dbpwd
trapp.dbhost
trapp.dbschema
```

If these variables don't exist, then the script falls back to reading credentials out of `trapp/connection.py` - so for any user of this package, you can supply your credentials in either location. I would probably recommend going the environment route, but YMMV.