### PR TITLE
Adds slight delay in game compilation; closes #85

### DIFF
--- a/trapp/compile_game.py
+++ b/trapp/compile_game.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import time
 from trapp.compiler import Compiler
 from trapp.gameevent import GameEvent
 from trapp.gameminute import GameMinute
@@ -78,6 +79,9 @@ class CompilerGames(Compiler):
             gs.saveDict(item, self.log)
 
             self.log.message('')
+
+            # Trying a delay to prevent buffer space problems
+            time.sleep(0.01)
 
         return True
 


### PR DESCRIPTION
With a delay of 0.01 second, the problem of a full buffer is avoided, and the processing time for 77,000+ records isn't made too interminable (about 45 minutes for a full run).

There are probably still optimizations to be found here, but this gets the script down into the timeframe of my existing script.