### PR TITLE
Changes MySQL to use -rf version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'xlrd',
-        'mysql-connector-python',
+        'mysql-connector-python-rf',
     ],
     dependency_links=[
         'http://dev.mysql.com/downloads/connector/python/',


### PR DESCRIPTION
This is a reaction to a problem I ran into with Travis, which led to a discussion about Oracle's distribution of `mysql-connection-python`. The full details are here:

travis-ci/travis-ci#5369

Eventually, I may need to move to PyMySQL, but for now I'm just standardizing on mysql-connector-python-rf.