### PR TITLE
Removes birthdate from player import

### DIFF
--- a/tests/fixtures/tbl_players.sql
+++ b/tests/fixtures/tbl_players.sql
@@ -20,7 +20,7 @@ DROP TABLE IF EXISTS `tbl_players`;
 CREATE TABLE `tbl_players` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
   `LastName` varchar(255) DEFAULT NULL,
-  `FirstName` varchar(255) DEFAULT NULL,
+  `FirstName` varchar(255) DEFAULT '',
   `Position` varchar(255) DEFAULT '',
   `RosterNumber` int(3) unsigned DEFAULT NULL,
   `Picture` varchar(50) DEFAULT 'coming_soon.gif',

--- a/trapp/import_player.py
+++ b/trapp/import_player.py
@@ -8,7 +8,7 @@ class ImporterPlayers(Importer):
 
     def correctValues(self):
         for record in self.records:
-            record['DOB'] = self.source.recoverDate(record['DOB'])
+            record['DOB'] = ''
 
         return True
 

--- a/trapp/import_player.py
+++ b/trapp/import_player.py
@@ -13,12 +13,17 @@ class ImporterPlayers(Importer):
         return True
 
     def importRecord(self, record):
+        record['PlayerName'] = (
+            record['FirstName'] + " " + record['LastName']
+        ).strip()
+
         self.log.message('Importing player ' + str(record))
+
         p = Player()
         p.connectDB()
 
         # Does the record exist?
-        found = p.lookupID(record, self.log)
+        found = p.lookupIDbyName(record, self.log)
         if (len(found) == 0):
             # Nothing found, so we import
             p.saveDict(record, self.log)
@@ -31,5 +36,7 @@ class ImporterPlayers(Importer):
         else:
             # Something(s) found, so we skip
             self.processMissingRecords(found, len(found))
+
+        self.log.message('')
 
         return True

--- a/trapp/import_player.py
+++ b/trapp/import_player.py
@@ -8,7 +8,8 @@ class ImporterPlayers(Importer):
 
     def correctValues(self):
         for record in self.records:
-            record['DOB'] = ''
+            if (record['DOB'] != ''):
+                record['DOB'] = self.source.recoverDate(record['DOB'])
 
         return True
 

--- a/trapp/import_player.py
+++ b/trapp/import_player.py
@@ -33,7 +33,7 @@ class ImporterPlayers(Importer):
             # Found one record, so we update
             record['PlayerID'] = found[0]
             p.saveDict(record, self.log)
-            self.imported += 1
+            self.updated += 1
         else:
             # Something(s) found, so we skip
             self.processMissingRecords(found, len(found))

--- a/trapp/importer.py
+++ b/trapp/importer.py
@@ -10,6 +10,7 @@ class Importer():
     def __init__(self, importFile, logFile):
         # Counters for reporting outcomes
         self.imported = 0
+        self.updated = 0
         self.skipped = 0
         self.errored = 0
         # List for storing missing records
@@ -146,9 +147,11 @@ class Importer():
     def reportStatus(self):
         self.log.message('\nImport results:')
         self.log.message(str(self.imported) + ' imported')
+        self.log.message(str(self.updated) + ' updated')
         self.log.message(str(self.skipped) + ' skipped')
         self.log.message(str(self.errored) + ' errored')
         print(str(self.imported) + ' imported')
+        print(str(self.updated) + ' updated')
         print(str(self.skipped) + ' skipped')
         print(str(self.errored) + ' errored')
         if (len(self.missing) > 0):

--- a/trapp/player.py
+++ b/trapp/player.py
@@ -54,7 +54,7 @@ class Player(Record):
         #   'Goalkeeper', 'Defender', 'Midfielder', 'Forward')
         # - DOB (date object)
         # - Hometown ('City, ST' for US/Canada, 'City, Country' otherwise)
-        required = ['FirstName', 'LastName', 'Position', 'Hometown']
+        required = ['FirstName', 'LastName', 'Position', 'DOB', 'Hometown']
         self.checkData(data, required)
 
         # See if any game matches these three terms
@@ -63,11 +63,17 @@ class Player(Record):
                'WHERE FirstName = %s '
                '  AND LastName = %s '
                '  AND Position = %s '
+               '  AND YEAR(DOB) = %s '
+               '  AND MONTH(DOB) = %s '
+               '  AND DAY(DOB) = %s '
                '  AND Hometown = %s')
         rs = self.db.query(sql, (
             data['FirstName'],
             data['LastName'],
             data['Position'],
+            data['DOB'][0],
+            data['DOB'][1],
+            data['DOB'][2],
             data['Hometown'],
         ))
         if (rs.with_rows):

--- a/trapp/player.py
+++ b/trapp/player.py
@@ -165,18 +165,14 @@ class Player(Record):
             # Update
             log.message('  ...Updating')
 
-            # Loops through sorted dictionary
-            # Builds the relevant SQL fields and values.
-            for item in sorted(newData):
-                if (newData[item] != '' and item in fieldList):
-                    fieldNames.append(item + ' = %s')
-                    fieldData.append(newData[item])
+            clauses = self.buildUpdateClauses(newData, fieldList)
 
             # Convert list to comma-separated string
-            fieldNames = ",".join(map(str, fieldNames))
+            fieldNames = ",".join(map(str, clauses["FieldNames"]))
 
             # Append PlayerID to field data
-            fieldData.append(newData['PlayerID'])
+            clauses["FieldData"].append(newData['PlayerID'])
+            fieldData = clauses["FieldData"]
 
             sql = 'UPDATE tbl_players SET ' + fieldNames + ' WHERE ID = %s'
 
@@ -184,16 +180,11 @@ class Player(Record):
             # Insert
             log.message('  ...Inserting')
 
-            # Loops through sorted dictionary
-            # Builds the relevant SQL fields and values.
-            for item in sorted(newData):
-                if (newData[item] != '' and item in fieldList):
-                    fieldNames.append(item)
-                    fieldHolders.append('%s')
-                    fieldData.append(newData[item])
+            clauses = self.buildInsertClauses(newData, fieldList)
 
-            fieldNames = ",".join(map(str, fieldNames))
-            fieldHolders = ",".join(map(str, fieldHolders))
+            fieldNames = ",".join(map(str, clauses["FieldNames"]))
+            fieldHolders = ",".join(map(str, clauses["FieldHolders"]))
+            fieldData = clauses["FieldData"]
 
             sql = ('INSERT INTO tbl_players (' + fieldNames + ') '
                    'VALUES '

--- a/trapp/player.py
+++ b/trapp/player.py
@@ -54,7 +54,7 @@ class Player(Record):
         #   'Goalkeeper', 'Defender', 'Midfielder', 'Forward')
         # - DOB (date object)
         # - Hometown ('City, ST' for US/Canada, 'City, Country' otherwise)
-        required = ['FirstName', 'LastName', 'Position', 'DOB', 'Hometown']
+        required = ['FirstName', 'LastName', 'Position', 'Hometown']
         self.checkData(data, required)
 
         # See if any game matches these three terms
@@ -63,17 +63,11 @@ class Player(Record):
                'WHERE FirstName = %s '
                '  AND LastName = %s '
                '  AND Position = %s '
-               '  AND YEAR(DOB) = %s '
-               '  AND MONTH(DOB) = %s '
-               '  AND DAY(DOB) = %s '
                '  AND Hometown = %s')
         rs = self.db.query(sql, (
             data['FirstName'],
             data['LastName'],
             data['Position'],
-            data['DOB'][0],
-            data['DOB'][1],
-            data['DOB'][2],
             data['Hometown'],
         ))
         if (rs.with_rows):
@@ -150,14 +144,12 @@ class Player(Record):
                    'FirstName = %s, '
                    'LastName = %s, '
                    'Position = %s, '
-                   'DOB = %s, '
                    'Hometown = %s '
                    'WHERE ID = %s')
             rs = self.db.query(sql, (
                 newData['FirstName'],
                 newData['LastName'],
                 newData['Position'],
-                self.db.convertDate(newData['DOB']),
                 newData['Hometown'],
                 newData['PlayerID'],
             ))
@@ -165,14 +157,13 @@ class Player(Record):
             # Insert
             log.message('  ...Inserting')
             sql = ('INSERT INTO tbl_players '
-                   '(FirstName, LastName, Position, DOB, Hometown) '
+                   '(FirstName, LastName, Position, Hometown) '
                    'VALUES '
-                   '(%s, %s, %s, %s, %s)')
+                   '(%s, %s, %s, %s)')
             rs = self.db.query(sql, (
                 newData['FirstName'],
                 newData['LastName'],
                 newData['Position'],
-                self.db.convertDate(newData['DOB']),
                 newData['Hometown'],
             ))
 

--- a/trapp/record.py
+++ b/trapp/record.py
@@ -17,6 +17,54 @@ class Record():
         self.db.disconnect()
         del self.db
 
+    def buildInsertClauses(self, data, fieldList):
+        # Loops through sorted dictionary, data
+        # Builds the relevant SQL fields and values.
+
+        # Everything comes back in a clauses dictionary
+        clauses = {}
+        clauses["FieldNames"] = []
+        clauses["FieldHolders"] = []
+        clauses["FieldData"] = []
+
+        for item in sorted(data):
+            if (data[item] != '' and item in fieldList):
+                clauses["FieldNames"].append(item)
+                clauses["FieldHolders"].append('%s')
+                if (item == 'DOB'):
+                    clauses["FieldData"].append(
+                        self.db.convertDate(data[item])
+                    )
+                else:
+                    clauses["FieldData"].append(
+                        data[item]
+                    )
+
+        return clauses
+
+    def buildUpdateClauses(self, data, fieldList):
+        # Loops through sorted dictionary, data
+        # Builds the relevant SQL fields and values.
+
+        # Everything comes back in a clauses dictionary
+        clauses = {}
+        clauses["FieldNames"] = []
+        clauses["FieldData"] = []
+
+        for item in sorted(data):
+            if (data[item] != '' and item in fieldList):
+                clauses["FieldNames"].append(item + ' = %s')
+                if (item == 'DOB'):
+                    clauses["FieldData"].append(
+                        self.db.convertDate(data[item])
+                    )
+                else:
+                    clauses["FieldData"].append(
+                        data[item]
+                    )
+
+        return clauses
+
     def checkData(self, data, required):
         # This checks a submitted data dictionary for required fields.
         # 1) data must be a dictionary


### PR DESCRIPTION
This is experimental. Based on the data published by MLS, player birthdays are not included on team roster pages - which makes scraping them just hard enough that it may not be worth trying to include them in a bulk harvester.

Other possible solutions here include:
- a more robust scraper that looks up player birthdays on individual pages (or some other trusted source)
- dropping DOB from the required field list (per this PR), but also adding a class of optional fields that would include DOB but also other fields like height, weight, etc
- probably something that I'm missing.