### PR TITLE
Slight improvements to lineup importer; skips future games

### DIFF
--- a/trapp/import_lineup.py
+++ b/trapp/import_lineup.py
@@ -4,6 +4,7 @@ from trapp.importer import Importer
 from trapp.game import Game
 from trapp.gameminute import GameMinute
 from trapp.player import Player
+from datetime import datetime
 
 
 class ImporterLineups(Importer):
@@ -43,14 +44,25 @@ class ImporterLineups(Importer):
             # We add that appearanceID, to ensure an update operation.
             player['ID'] = appearanceID[0]
             gm.saveDict(player, self.log)
-            self.imported += 1
+            self.updated += 1
         else:
             gm.saveDict(player, self.log)
             self.imported += 1
         return True
 
     def importRecord(self, record):
-        self.log.message('Importing lineup ' + str(record))
+        self.log.message('\nImporting lineup ' + str(record))
+
+        today = datetime.now()
+        gamedate = datetime(
+            record['Date'][0],
+            record['Date'][1],
+            record['Date'][2]
+        )
+        if (gamedate > today):
+            self.log.message('Game in the future - skip')
+            self.skipped += 1
+            return True
 
         # Need to identify gameID
         g = Game()
@@ -119,7 +131,8 @@ class ImporterLineups(Importer):
             batch = self.parsePlayer(starter, game, teamID, duration)
             for item in batch:
                 self.players.append(item)
-        self.log.message(str(self.players))
+        # Going to try removing this from the log, to see if it gets cleaner
+        # self.log.message(str(self.players))
 
         # This method returns nothing, as its work is recorded in
         # self.starters and self.players.

--- a/trapp/import_lineup.py
+++ b/trapp/import_lineup.py
@@ -27,6 +27,7 @@ class ImporterLineups(Importer):
 
     def correctValues(self):
         for record in self.records:
+            # Fix date format
             record['Date'] = self.source.recoverDate(record['Date'])
 
             # Look up Team and Opponent ID
@@ -66,6 +67,8 @@ class ImporterLineups(Importer):
     def importRecord(self, record):
         self.log.message('\nImporting lineup ' + str(record))
 
+        # If the game hasn't been played yet, move to the next
+        # Doesn't get recorded as a "skip" to keep reporting clean
         today = datetime.now()
         gamedate = datetime(
             record['Date'][0],
@@ -73,11 +76,10 @@ class ImporterLineups(Importer):
             record['Date'][2]
         )
         if (gamedate > today):
-            self.log.message('Game in the future - skip')
-            self.skipped += 1
+            self.log.message('Game has not been played yet')
             return True
 
-        # Need to identify gameID
+        # Start working with game record
         g = Game()
         g.connectDB()
 


### PR DESCRIPTION
This would fix #105 and also improve the log of the lineup importer. Specifically, it uses the new "updated" counter for records that already exist, and removes an unneeded log entry of the entire lineup object (which is then logged separately as each entry is processed)