### PR TITLE
Tweaked goals importer

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -75,7 +75,17 @@ def test_importer_lookupPlayerID_valid(excel):
     log = Log('test.log')
     importer = ImporterGoals(excel, log)
     # We don't worry about invalid data formats, as those are caught by player object
-    event = {'playername': 'Man', 'TeamID': 2, 'GameID': 1}
+    event = {'playername': 'Man', 'TeamID': 2, 'GameID': 1, 'Event': 1}
+    event = importer.lookupPlayerID(event)
+    assert event['PlayerID'] == 3
+    assert importer.skipped == 0
+
+
+def test_importer_lookupPlayerID_owngoal(excel):
+    log = Log('test.log')
+    importer = ImporterGoals(excel, log)
+    # We don't worry about invalid data formats, as those are caught by player object
+    event = {'playername': 'Man', 'TeamID': 1, 'GameID': 1, 'Event': 6, 'OpponentID': 2}
     event = importer.lookupPlayerID(event)
     assert event['PlayerID'] == 3
     assert importer.skipped == 0
@@ -86,7 +96,7 @@ def test_importer_lookupPlayerID_valid(excel):
     importer = ImporterGoals(excel, log)
     # Invalid records get run through disambiguation
     with mock.patch('__builtin__.raw_input', return_value=0):
-        event = {'playername': 'Invalid Player', 'TeamID': 2, 'GameID': 1}
+        event = {'playername': 'Invalid Player', 'TeamID': 2, 'GameID': 1, 'Event': 1}
         assert importer.lookupPlayerID(event) is False
         assert importer.skipped == 1
 
@@ -133,18 +143,19 @@ def test_importer_parseOneGoal(excel):
     importer = ImporterGoals(excel, log)
     game = 1
     team = 1
+    opponent = 2
     goals = ""
     # assert importer.parseGoals(goals) == [{}]
     goals = "Player (unassisted) 78"
-    assert importer.parseOneGoal(goals, game, team) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': '', 'GameID': 1, 'TeamID': 1}]
+    assert importer.parseOneGoal(goals, game, team, opponent) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': '', 'GameID': 1, 'TeamID': 1, 'OpponentID': 2}]
     goals = "Player (penalty) 78"
-    assert importer.parseOneGoal(goals, game, team) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': 'penalty kick', 'GameID': 1, 'TeamID': 1}]
+    assert importer.parseOneGoal(goals, game, team, opponent) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': 'penalty kick', 'GameID': 1, 'TeamID': 1, 'OpponentID': 2}]
     goals = "Player (Potter) 78"
-    assert importer.parseOneGoal(goals, game, team) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': '', 'GameID': 1, 'TeamID': 1}, {'playername': 'Potter', 'MinuteID': 78, 'Event': 2, 'Notes': '', 'GameID': 1, 'TeamID': 1}]
+    assert importer.parseOneGoal(goals, game, team, opponent) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': '', 'GameID': 1, 'TeamID': 1, 'OpponentID': 2}, {'playername': 'Potter', 'MinuteID': 78, 'Event': 2, 'Notes': '', 'GameID': 1, 'TeamID': 1}]
     goals = "Player (Potter, Rains) 78"
-    assert importer.parseOneGoal(goals, game, team) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': '', 'GameID': 1, 'TeamID': 1}, {'playername': 'Potter', 'MinuteID': 78, 'Event': 2, 'Notes': '', 'GameID': 1, 'TeamID': 1}, {'playername': 'Rains', 'MinuteID': 78, 'Event': 3, 'Notes': '', 'GameID': 1, 'TeamID': 1}]
+    assert importer.parseOneGoal(goals, game, team, opponent) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 1, 'Notes': '', 'GameID': 1, 'TeamID': 1, 'OpponentID': 2}, {'playername': 'Potter', 'MinuteID': 78, 'Event': 2, 'Notes': '', 'GameID': 1, 'TeamID': 1}, {'playername': 'Rains', 'MinuteID': 78, 'Event': 3, 'Notes': '', 'GameID': 1, 'TeamID': 1}]
     goals = "Player (own goal) 78"
-    assert importer.parseOneGoal(goals, game, team) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 6, 'Notes': 'own goal', 'GameID': 1, 'TeamID': 1}]
+    assert importer.parseOneGoal(goals, game, team, opponent) == [{'playername': 'Player', 'MinuteID': 78, 'Event': 6, 'Notes': 'own goal', 'GameID': 1, 'TeamID': 1, 'OpponentID': 2}]
 
 
 def test_importer_parseMinuteDoesNothing(excel):

--- a/trapp/import_goal.py
+++ b/trapp/import_goal.py
@@ -110,9 +110,11 @@ class ImporterGoals(Importer):
                 # We already have a record of this event.
                 # We add that eventID to ensure an update.
                 item['ID'] = eventID[0]
-
-            e.saveDict(item, self.log)
-            self.imported += 1
+                e.saveDict(item, self.log)
+                self.updated += 1
+            else:
+                e.saveDict(item, self.log)
+                self.imported += 1
 
         return True
 

--- a/trapp/import_goal.py
+++ b/trapp/import_goal.py
@@ -23,6 +23,15 @@ class ImporterGoals(Importer):
             self.log.message('\nParsing game record:')
             # self.log.message('  ' + str(record) + '\n')
 
+            # NewEvents holds the rebuilt event records - we create it this
+            # early because the next step skips this record when no goals
+            # are scored - and it still needs to be present.
+            record['NewEvents'] = []
+
+            # Games with no goals get skipped
+            if (record['Goals'] == ''):
+                continue
+
             # 1. TeamID lookup
             teamID = self.lookupTeamID(record['Team'])
 
@@ -64,7 +73,6 @@ class ImporterGoals(Importer):
 
             # 5. The goalscorers string needs to be expanded
             record['Events'] = self.splitGoals(record['Goals'])
-            record['NewEvents'] = []
             # record['Events'] is now a list of strings. We now need to parse
             # each individual string into a dictionary.
             for item in record['Events']:


### PR DESCRIPTION
This implements some needed improvements from the first time this code was used against real goals data:
- Skips game records with no goals scored
- Fixes a bug where own goal scorers were looked up against the scoring team, rather than the defending team
- Implements the new "updated" counter