### PR TITLE
Longer span for check-games, and column labels

### DIFF
--- a/tests/test_checkgame.py
+++ b/tests/test_checkgame.py
@@ -19,9 +19,8 @@ def test_checkerGames_checkGames():
     c.checkGames()
     # Re-open output in read mode
     output.file = open('test.csv', 'r')
-    # Default start year is 2012, but sample games are in 1980.
-    # This is by design, to give a negative test.
-    assert output.file.readline() == ''
+    # Check for column labels in output
+    assert output.file.readline() == 'Competition,Year,Games\n'
 
 
 def test_checkerGames_reviewCompetition():

--- a/trapp/check_games.py
+++ b/trapp/check_games.py
@@ -28,13 +28,17 @@ class CheckerGames(Checker):
 
     def checkGames(self):
         # What year are we starting our checks
-        startYear = 2012
+        startYear = 1990
+
+        # Label Columns
+        self.output.message('Competition,Year,Games')
 
         # Get Competitions list
         c = Competition()
         c.connectDB()
         competitions = c.loadAll()
 
+        # Do work
         [self.reviewCompetition(record['CompetitionID'], startYear)
          for record
          in competitions]


### PR DESCRIPTION
This extends the default date range for `check-games` back to 1990, instead of 2012. It also adds column headings to the output, for easier generation of pivot tables when reading the output in Excel.