### PR TITLE
Updates tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ matrix:
   include:
     - python: "2.7"
       env: "COVERAGE=1"
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
       env: "COVERAGE=1"
     - python: "3.8"
+    - python: "3.9"
     - python: "nightly"
   allow_failures:
-    - python: "3.5"
+    - python: "2.7"
     - python: "3.6"
-    - python: "3.7"
     - python: "3.8"
+    - python: "3.9"
     - python: "nightly"
 install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trapp
 
-[![Build Status](https://travis-ci.org/matt-bernhardt/trapp.svg)](https://travis-ci.org/matt-bernhardt/trapp) [![Coverage Status](https://coveralls.io/repos/matt-bernhardt/trapp/badge.svg?branch=master&service=github)](https://coveralls.io/github/matt-bernhardt/trapp?branch=master) [![Code Climate](https://codeclimate.com/github/matt-bernhardt/trapp/badges/gpa.svg)](https://codeclimate.com/github/matt-bernhardt/trapp)
+[![Build Status](https://travis-ci.org/matt-bernhardt/trapp.svg)](https://travis-ci.org/matt-bernhardt/trapp) [![Coverage Status](https://coveralls.io/repos/matt-bernhardt/trapp/badge.svg?branch=main&service=github)](https://coveralls.io/github/matt-bernhardt/trapp?branch=main) [![Code Climate](https://codeclimate.com/github/matt-bernhardt/trapp/badges/gpa.svg)](https://codeclimate.com/github/matt-bernhardt/trapp)
 
 Trapp is a Python project for linking, analyzing, and extending soccer data.
 


### PR DESCRIPTION
This does two things:

1. Updates what versions of Python are used on Travis (adding 3.9, removing 3.5, and declaring failures acceptable for 2.7).
2. Updates the badges on the readme file to assume a base branch of `main`, rather than `master`.